### PR TITLE
Удаляет служебные файлы vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "javascript.validate.enable": false
-}


### PR DESCRIPTION
Кажется, что конфигам не место в проектах.
Сам часто страдаю от .idea.

Если тебе самому не очень нравятся эти служебные файлы, то ты можешь их добавить в .gitignore, но не уровне проекта, а на глобальном. И забыть о служебных папках. Вот пример - https://gist.github.com/subfuzion/db7f57fff2fb6998a16c