### PR TITLE
Fix obvious typo in incline()

### DIFF
--- a/src/incline.js
+++ b/src/incline.js
@@ -64,7 +64,7 @@ export function incline(
   }
 
   if (person.middle) {
-    res.last = inclineMiddlename(person.middle.trim(), declension, res.gender);
+    res.middle = inclineMiddlename(person.middle.trim(), declension, res.gender);
   }
 
   return res;


### PR DESCRIPTION
If you try to incline full name, lvovich rewrites lastname:

```javascript
lvovich.incline({ first: 'Иван', middle: 'Иванович', last: 'Иванов' }, 'genitive')
// returns { gender: "male", first: "Ивана", last: "Ивановича" }
```

This PR fixes it